### PR TITLE
Make it work with a generic HTTPS endpoint

### DIFF
--- a/analytics/__init__.py
+++ b/analytics/__init__.py
@@ -6,6 +6,7 @@ __version__ = VERSION
 
 """Settings."""
 write_key = None
+endpoint = 'https://api.segment.io/v1/batch'
 on_error = None
 debug = False
 send = True
@@ -50,7 +51,7 @@ def _proxy(method, *args, **kwargs):
     global default_client
     if not default_client:
         default_client = Client(write_key, debug=debug, on_error=on_error,
-                                send=send)
+                                send=send, endpoint=endpoint)
 
     fn = getattr(default_client, method)
     fn(*args, **kwargs)

--- a/analytics/client.py
+++ b/analytics/client.py
@@ -25,12 +25,14 @@ class Client(object):
     log = logging.getLogger('segment')
 
     def __init__(self, write_key=None, debug=False, max_queue_size=10000,
-                 send=True, on_error=None):
+                 send=True, on_error=None, endpoint=None):
         require('write_key', write_key, string_types)
 
         self.queue = queue.Queue(max_queue_size)
-        self.consumer = Consumer(self.queue, write_key, on_error=on_error)
+        self.consumer = Consumer(self.queue, write_key, endpoint=endpoint,
+                                 on_error=on_error)
         self.write_key = write_key
+        self.endpoint = endpoint
         self.on_error = on_error
         self.debug = debug
         self.send = send

--- a/analytics/request.py
+++ b/analytics/request.py
@@ -9,17 +9,16 @@ from requests import sessions
 _session = sessions.Session()
 
 
-def post(write_key, **kwargs):
+def post(write_key, endpoint, **kwargs):
     """Post the `kwargs` to the API"""
     log = logging.getLogger('segment')
     body = kwargs
     body["sentAt"] = datetime.utcnow().replace(tzinfo=tzutc()).isoformat()
-    url = 'https://api.segment.io/v1/batch'
     auth = HTTPBasicAuth(write_key, '')
     data = json.dumps(body, cls=DatetimeSerializer)
-    headers = { 'content-type': 'application/json' }
+    headers = { 'content-type': 'application/json', 'x-api-key': write_key }
     log.debug('making request: %s', data)
-    res = _session.post(url, data=data, auth=auth, headers=headers, timeout=15)
+    res = _session.post(endpoint, data=data, auth=auth, headers=headers, timeout=15)
 
     if res.status_code == 200:
         log.debug('data uploaded successfully')

--- a/analytics/test/request.py
+++ b/analytics/test/request.py
@@ -2,13 +2,14 @@ from datetime import datetime, date
 import unittest
 import json
 
+import analytics
 from analytics.request import post, DatetimeSerializer
 
 
 class TestRequests(unittest.TestCase):
 
     def test_valid_request(self):
-        res = post('testsecret', batch=[{
+        res = post('testsecret', analytics.endpoint, batch=[{
             'userId': 'userId',
             'event': 'python event',
             'type': 'track'


### PR DESCRIPTION
Say hello to Polku's Python SDK. It works like this:

```
import analytics
analytics.write_key='AWS_API_GATEWAY_KEY'
analytics.endpoint='https://polku.fih.io/dev/[hookname]'
analytics.track('kljsdgs99', 'SignedUp', {'plan': 'Enterprise'})
```

This should be a drop-in replacement for Segment's original SDK. It also works with Segment by just not specifying any custom `analytics.endpoint`.