### PR TITLE
Remove duplicated retry logic

### DIFF
--- a/analytics/consumer.py
+++ b/analytics/consumer.py
@@ -29,7 +29,6 @@ class Consumer(Thread):
         # pause immediately after construction, we might set running to True in
         # run() *after* we set it to False in pause... and keep running forever.
         self.running = True
-        self.retries = 3
 
     def run(self):
         """Runs the consumer."""
@@ -79,10 +78,5 @@ class Consumer(Thread):
         return items
 
     def request(self, batch, attempt=0):
-        """Attempt to upload the batch and retry before raising an error """
-        try:
-            post(self.write_key, self.endpoint, batch=batch)
-        except:
-            if attempt > self.retries:
-                raise
-            self.request(batch, attempt+1)
+        """Attempt to upload the batch """
+        post(self.write_key, self.endpoint, batch=batch)

--- a/analytics/version.py
+++ b/analytics/version.py
@@ -1,1 +1,1 @@
-VERSION = '1.2.9'
+VERSION = '1.3.0'


### PR DESCRIPTION
This PR removes the retry logic that comes built-in with the upstream Segment SDK. The logic is not needed since we added our own logic that uses exponential backoff in a previous release.

There is another reason why we should remove the built-in retry logic: it effectively increases the max retry delay to 60 seconds (from the intended 20 seconds). This can lead to errors being silenced for too long.